### PR TITLE
docker-compose up時に自動でDBのmigrationが実行されるようにした。

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,6 @@ services:
     ports:
       - '80:80'
       - '443:443'
-    links:
-      - app
-      - nuxt
     restart: always
 
   # node:
@@ -38,8 +35,8 @@ services:
 
   app:
     build: docker/php-fpm
-    links:
-         - mysql
+    depends_on:
+      - mysql
     environment:
       DB_HOST: 'mysql'
       DB_NAME: 'pascal'
@@ -47,6 +44,8 @@ services:
       DB_PASS: 'uKXSjP3B4PDm'
     volumes:
       - ./src/laravel/:/var/www/html/laravel
+    working_dir: /var/www/html/laravel
+    command: [bash, -c, /opt/entrypoint.sh mysql pascal uKXSjP3B4PDm php artisan migrate && php-fpm]
 
   data:
     image: busybox

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,9 +1,12 @@
 FROM php:7.1-fpm
 
 ADD php.ini /usr/local/etc/php/conf.d/php.ini
+ADD entrypoint.sh /opt/entrypoint.sh
+RUN chmod a+x /opt/entrypoint.sh
 
 RUN apt-get update \
   && docker-php-ext-install pdo_mysql mysqli mbstring
+RUN apt-get install -y mysql-client
 
 ENV PHPREDIS_VERSION php7
 

--- a/docker/php-fpm/entrypoint.sh
+++ b/docker/php-fpm/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+host="$1"
+shift
+user="$1"
+shift
+password="$1"
+shift
+cmd="$@"
+
+until mysql -h"$host" -u"$user" -p"$password"; do
+  >&2 echo -n "."
+  sleep 1
+done
+
+>&2 echo "MySQL is up - executing command"
+exec $cmd

--- a/src/laravel/database/migrations/2018_04_01_100000_create_initial_tables.php
+++ b/src/laravel/database/migrations/2018_04_01_100000_create_initial_tables.php
@@ -15,14 +15,14 @@ class CreateInitialTables extends Migration
     {
         Schema::create('rooms', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('name')->comment('チャットルーム名');
+            $table->string('name')->index()->comment('チャットルーム名');
             $table->timestamps();
         });
 
         Schema::create('comments', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('room_id')->index()->comment('チャットルームID');
-            $table->unsignedBigInteger('user_name')->comment('ユーザー名');
+            $table->string('user_name')->comment('ユーザー名');
             $table->text('comment')->comment('コメント');
             $table->timestamps();
         });


### PR DESCRIPTION
appコンテナからmysqlコンテナを監視し、mysqlの起動が完了したらphp artisan migrateが走る。

リポジトリをpullしてdocker-compose upしたら動くはず。
hostsで127.0.0.1に対してlocal.pascal.comを割り当てる必要がある。